### PR TITLE
disable debug spam when no debug defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
   register:   _netplan_configs
 
 - debug:      var=_netplan_configs
+  when: debug is defined and ( debug | bool )
 
 - name:       Removing Existing Configurations
   file:


### PR DESCRIPTION
reduces the output for production environments
to get the debug message run the playbook with '--extra-vars="debug=true"'