### PR TITLE
Provide a facility to skip `netplan apply`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,5 @@ netplan_packages:
   - netplan.io
 
 netplan_pri_domain: example.org
+
+netplan_apply: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,3 +8,4 @@
 - name:       Applying Netplan Configuration
   command:    netplan apply
   listen:     netplan apply config
+  when:       netplan_apply


### PR DESCRIPTION
This patch provides a variable that can be set to toggle the `netplan
apply` call. This provides users with the ability to configure netplan,
but postpone the apply until later. This addresses #10.