### PR TITLE
Provide a facility to skip checking for netplan packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,4 +85,6 @@ netplan_packages:
 
 netplan_pri_domain: example.org
 
+netplan_check_install: True
+
 netplan_apply: True

--- a/tasks/netplan.yml
+++ b/tasks/netplan.yml
@@ -1,5 +1,7 @@
 ---
 - import_tasks: install.yml
+  when:
+    - netplan_check_install
 
 - import_tasks: existing.yml
   when:


### PR DESCRIPTION
Similar to 75b0fe6, provide a variable that can be set to disable
checking for the netplan packages.  This is helpful in situations
where the target node in question is an ansolute minimal installation
(e.g., does not even include `apt` / `dpkg`).

Signed-off-by: Jeff Squyres <jeff@squyres.com>