### PR TITLE
Change default renderer to not specified which will default to systemd-networkd.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ netplan_config_file: /etc/netplan/ansible-config.yaml
 # switch to enable/disable the role completely
 netplan_enabled: true
 
-# Configured devices get handled by systemd-networkd by default, unless explicitly marked as managed by a specific renderer (NetworkManager) 
+# Configured devices get handled by systemd-networkd by default, unless explicitly marked as managed by a specific renderer (NetworkManager)
 netplan_renderer:
 
 netplan_configuration:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ netplan_config_file: /etc/netplan/ansible-config.yaml
 # switch to enable/disable the role completely
 netplan_enabled: true
 
-# Configured devices get handled by systemd-networkd by default, unless explicitly marked as managed by a specific renderer (NetworkManager, networkd) 
+# Configured devices get handled by systemd-networkd by default, unless explicitly marked as managed by a specific renderer (NetworkManager) 
 netplan_renderer:
 
 netplan_configuration:
@@ -85,6 +85,6 @@ netplan_packages:
 
 netplan_pri_domain: example.org
 
-netplan_check_install: False
+netplan_check_install: True
 
 netplan_apply: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 # defaults file for ansible-netplan
-netplan_config_file: /etc/netplan/config.yaml
+netplan_config_file: /etc/netplan/ansible-config.yaml
 
 # switch to enable/disable the role completely
 netplan_enabled: true
 
-# Either networkd or NetworkManager
-netplan_renderer: networkd
+# Configured devices get handled by systemd-networkd by default, unless explicitly marked as managed by a specific renderer (NetworkManager, networkd) 
+netplan_renderer:
 
 netplan_configuration:
   {}
@@ -85,6 +85,6 @@ netplan_packages:
 
 netplan_pri_domain: example.org
 
-netplan_check_install: True
+netplan_check_install: False
 
 netplan_apply: True

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,8 +10,8 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - artful
         - bionic
+        - focal
 
   galaxy_tags:
     - networking

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,7 +1,7 @@
 ---
 network:
   version: {{ netplan_configuration['network']['version']|default('2') }}
-{% if netplan_renderer  is not none %}
+{% if netplan_renderer is not none %}
   renderer: {{ netplan_renderer }}
 {% endif %}
 {% if netplan_configuration['network']['ethernets'] is defined %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -1,7 +1,9 @@
 ---
 network:
   version: {{ netplan_configuration['network']['version']|default('2') }}
+{% if netplan_renderer  is not none %}
   renderer: {{ netplan_renderer }}
+{% endif %}
 {% if netplan_configuration['network']['ethernets'] is defined %}
   ethernets:
 {{ netplan_configuration['network']['ethernets']|to_nice_yaml|indent(4, true) }}


### PR DESCRIPTION
no renderer specified will default to systemd-networkd, it's the new ubuntu standard.

Change default config name to ansible-config.yaml, it helps to identify that the config is managed by ansible.

