### PR TITLE
changed value for netplan_remove_existing to false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,7 @@ netplan_configuration:
   #       id: 15
   #       link: enp0s25
 
-netplan_remove_existing: true
+netplan_remove_existing: false
 
 netplan_packages:
   - nplan


### PR DESCRIPTION
I think it's dangerous to have `netplan_remove_existing` variable set to `true` by default.