### PR TITLE
Add configuration backup on changes

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,7 +3,7 @@
   template:
     src: etc/netplan/config.yaml.j2
     dest: "{{ netplan_config_file }}"
-  backup: true
+    backup: true
   become: true
   when: netplan_configuration != []
   notify: netplan generate config

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,6 +3,7 @@
   template:
     src: etc/netplan/config.yaml.j2
     dest: "{{ netplan_config_file }}"
+  backup: true
   become: true
   when: netplan_configuration != []
   notify: netplan generate config


### PR DESCRIPTION
Just added backup option to template task

## Description
Backups of network configuration can often save you time if there were changes made manually and you realize that only after making changes.

## Related Issue
#28

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
