### PR TITLE
Add tunnel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ that can be set for this role.
               addresses:
                 - 10.11.12.99/24
 ```
+## Using vaulted variables
+Vault encrypted variables need to be defined outside the `netplan_configuration` variable to be evaluated.
+
+```yaml
+netplan_configuration:
+  network:
+    version: 2
+    tunnels:
+      wg_test:
+        mode: wireguard
+        key: "{{ my_wireguard_private_key }}"
+      ....
+
+my_wireguard_private_key: !vault |
+          31366530666465373834386563636465636135323562303866363333333865376330303130363162
+          ....
+```
 
 ## License
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,8 @@
 galaxy_info:
   author: Larry Smith Jr.
   description: An [Ansible](https://www.ansible.com) role to manage [Netplan](https://netplan.io)
+  role_name: netplan
+  namespace: mrlesmithjr
 
   license: MIT
 

--- a/molecule/wireguard/converge.yml
+++ b/molecule/wireguard/converge.yml
@@ -1,0 +1,34 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    # netplan_renderer: 'NetworkManager'
+    debug: true
+    netplan_configuration:
+      network:
+        version: 2
+        tunnels:
+          wg_test:
+            mode: wireguard
+            addresses:
+              - 10.42.42.2/32
+            nameservers:
+              addresses:
+                - 10.10.10.1
+              search:
+                - dns.example.com
+            key: 'gDdP5JHM6VQQOeGZPLANiTMa+V2bbwyR8Z2o86m7gUg='
+            peers:
+              - keys:
+                  public: 'KqOQG90uvqVWGHwLW+Z5tH019Qt5QcIhpKitIovkviA='
+                allowed-ips:
+                  - 10.10.10.0/24
+                keepalive: 15
+                endpoint: 'wireguard.example.com:51820'
+            routes:
+              - to: 10.10.10.0/24
+  tasks:
+    - name: "Include ansible-netplan"
+      include_role:
+        name: "mrlesmithjr.netplan"

--- a/molecule/wireguard/converge.yml
+++ b/molecule/wireguard/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: true
   vars:
-    # netplan_renderer: 'NetworkManager'
+    netplan_renderer: 'NetworkManager'
     debug: true
     netplan_configuration:
       network:

--- a/molecule/wireguard/molecule.yml
+++ b/molecule/wireguard/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-certs: true
+    ignore-errors: true
+driver:
+  name: vagrant
+platforms:
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 4048
+    cpus: 4
+    instance_raw_config_args:
+      - "vm.network 'forwarded_port', guest: 8081, host: 30080"
+provisioner:
+  name: ansible
+  lint: ansible-lint --force-color
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+verifier:
+  name: ansible

--- a/molecule/wireguard/prepare.yml
+++ b/molecule/wireguard/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'

--- a/molecule/wireguard/verify.yml
+++ b/molecule/wireguard/verify.yml
@@ -1,0 +1,55 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  vars:
+    # netplan_renderer: 'NetworkManager'
+    netplan_configuration:
+      network:
+        version: '2'
+        tunnels:
+          wg_test:
+            mode: wireguard
+            addresses:
+              - 10.42.42.2/32
+            nameservers:
+              addresses:
+                - 10.10.10.1
+              search:
+                - dns.example.com
+            key: 'gDdP5JHM6VQQOeGZPLANiTMa+V2bbwyR8Z2o86m7gUg='
+            peers:
+              - keys:
+                  public: 'KqOQG90uvqVWGHwLW+Z5tH019Qt5QcIhpKitIovkviA='
+                allowed-ips:
+                  - 10.10.10.0/24
+                keepalive: '15'
+                endpoint: 'wireguard.example.com:51820'
+            routes:
+              - to: 10.10.10.0/24
+  become: true
+  become_user: root
+  tasks:
+    - name: Read netplan config
+      ansible.builtin.slurp:
+        src: '/etc/netplan/ansible-config.yaml'
+      register: netplan_wg_config_encoded
+
+    - name: Check wireguard config
+      ansible.builtin.assert:
+        that:
+          - netplan_configuration.network.version in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.mode in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.addresses[0] in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.nameservers.addresses[0] in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.nameservers.search[0] in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.key in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.peers[0]['keys']['public'] in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.peers[0]['allowed-ips'][0] in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.peers[0].keepalive in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.peers[0].endpoint in netplan_wg_config
+          - netplan_configuration.network.tunnels.wg_test.routes[0].to in netplan_wg_config
+      vars:
+        - netplan_wg_config: "{{ netplan_wg_config_encoded.content | b64decode }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,3 +6,12 @@
   become: true
   register: result
   until: result is successful
+
+- name: Install network-manager when used as renderer
+  apt:
+    name: "{{ netplan_networkmanager_pkt }}"
+    state: present
+  become: true
+  register: result
+  until: result is successful
+  when: netplan_renderer == 'NetworkManager'

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -24,3 +24,7 @@ network:
   vlans:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% if netplan_configuration['network']['tunnels'] is defined %}
+  tunnels:
+{{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
+{% endif %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
+netplan_networkmanager_pkt: 'network-manager'
 # vars file for ansible-netplan


### PR DESCRIPTION
Add tunnels config block to netplan config generation.
Add molecule test testing a tunnels config with wireguard.
Install NetworkManger Pkt when used as renderer.

## Description
After using your great role for a while I discovered that it is not ready for tunnels setup.
I added the tunnel setup and a test using molecule. 


