### PR TITLE
Removed is defined check from config.yaml.j2

### DIFF
--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -4,27 +4,27 @@ network:
 {% if netplan_renderer is not none %}
   renderer: {{ netplan_renderer }}
 {% endif %}
-{% if netplan_configuration['network']['ethernets'] is defined %}
+{% if netplan_configuration['network']['ethernets'] %}
   ethernets:
 {{ netplan_configuration['network']['ethernets']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['wifis'] is defined %}
+{% if netplan_configuration['network']['wifis'] %}
   wifis:
 {{ netplan_configuration['network']['wifis']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['bonds'] is defined %}
+{% if netplan_configuration['network']['bonds'] %}
   bonds:
 {{ netplan_configuration['network']['bonds']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['bridges'] is defined %}
+{% if netplan_configuration['network']['bridges'] %}
   bridges:
 {{ netplan_configuration['network']['bridges']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['vlans'] is defined %}
+{% if netplan_configuration['network']['vlans'] %}
   vlans:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['tunnels'] is defined %}
+{% if netplan_configuration['network']['tunnels'] %}
   tunnels:
 {{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
 {% endif %}


### PR DESCRIPTION
## Description
By removing the 'if <object> is defined' check and just using 'if <object>' in the template, the template can now support `omit` values that are technically defined but should be treated by roles as undefined, so they evaluate as false.

An example where this is useful is in a playbook using this role some hosts might have wifi capabilities while others do not, and so a host_var might have a list of access points or a blank string. By setting the blank string to omit before passing it to this role the wifi section of the config would not be included without throwing any errors.

Currently, it does throw an error if omit is passed to it since `omit` is defined but has no information the template needs to run.

## Related Issue
#36 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ * ] I have read the **CONTRIBUTING** document.(Doesnt seem to exist)
- [ * ] I have run the pre-merge tests locally and they pass. No clear instructions on what those procedures are but the changes worked for me locally
- [ * ] I have updated the documentation accordingly.
- [ * ] I have added tests to cover my changes. Doesnt seem to be a currently existing test to modify for this template
- [ * ] All new and existing tests passed.
