### PR TITLE
fix: Added back in the is defined check and nested falsy check

### DIFF
--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -4,27 +4,27 @@ network:
 {% if netplan_renderer is not none %}
   renderer: {{ netplan_renderer }}
 {% endif %}
-{% if netplan_configuration['network']['ethernets'] is defined %}
+{% if netplan_configuration['network']['ethernets'] %}
   ethernets:
 {{ netplan_configuration['network']['ethernets']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['wifis'] is defined %}
+{% if netplan_configuration['network']['wifis'] %}
   wifis:
 {{ netplan_configuration['network']['wifis']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['bonds'] is defined %}
+{% if netplan_configuration['network']['bonds'] %}
   bonds:
 {{ netplan_configuration['network']['bonds']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['bridges'] is defined %}
+{% if netplan_configuration['network']['bridges'] %}
   bridges:
 {{ netplan_configuration['network']['bridges']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['vlans'] is defined %}
+{% if netplan_configuration['network']['vlans'] %}
   vlans:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['tunnels'] is defined %}
+{% if netplan_configuration['network']['tunnels'] %}
   tunnels:
 {{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
 {% endif %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -4,27 +4,33 @@ network:
 {% if netplan_renderer is not none %}
   renderer: {{ netplan_renderer }}
 {% endif %}
+{% if netplan_configuration['network']['ethernets'] is defined %}
 {% if netplan_configuration['network']['ethernets'] %}
   ethernets:
 {{ netplan_configuration['network']['ethernets']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% endif %}
+{% if netplan_configuration['network']['wifis'] is defined %}
 {% if netplan_configuration['network']['wifis'] %}
   wifis:
 {{ netplan_configuration['network']['wifis']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% endif %}
+{% if netplan_configuration['network']['bonds'] is defined %}
 {% if netplan_configuration['network']['bonds'] %}
   bonds:
 {{ netplan_configuration['network']['bonds']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% endif %}
+{% if netplan_configuration['network']['bridges'] is defined %}
 {% if netplan_configuration['network']['bridges'] %}
   bridges:
 {{ netplan_configuration['network']['bridges']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% endif %}
+{% if netplan_configuration['network']['vlans'] is defined %}
 {% if netplan_configuration['network']['vlans'] %}
   vlans:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
-{% if netplan_configuration['network']['tunnels'] %}
-  tunnels:
-{{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
 {% endif %}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -34,7 +34,7 @@ network:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
 {% endif %}
-{% if netplan_configuration['network']['tunnels'] is defined%}
+{% if netplan_configuration['network']['tunnels'] is defined %}
 {% if netplan_configuration['network']['tunnels'] %}
   tunnels:
 {{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -34,3 +34,9 @@ network:
 {{ netplan_configuration['network']['vlans']|to_nice_yaml|indent(4, true) }}
 {% endif %}
 {% endif %}
+{% if netplan_configuration['network']['tunnels'] is defined%}
+{% if netplan_configuration['network']['tunnels'] %}
+  tunnels:
+{{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
## Description
Found an issue while testing my previous PR where an undefined value would cause an error. 

The alternative to this would be creating a default network map with values defaulted to omit, which may be preferable since there is an example block commented out in the defaults file. 

However, the slightly easier solution was to nest the if `<object name>` check inside of the is defined check so it'll only run when the object is defined but will still catch omit values at the inner `if`
## Related Issue
#36 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
