### PR TITLE
Bugfix add mode 0600 to netplan config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 # defaults file for ansible-netplan
 netplan_config_file: /etc/netplan/ansible-config.yaml
 
+# File permissions for netplan config file.
+netplan_config_file_mode: '0600'
+
 # switch to enable/disable the role completely
 netplan_enabled: true
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,6 +3,7 @@
   template:
     src: etc/netplan/config.yaml.j2
     dest: "{{ netplan_config_file }}"
+    mode: "{{ netplan_config_file_mode}}"
     backup: true
   become: true
   when: netplan_configuration != []


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
newer netplan on Debian Sid errored because of file permission being too open.  Added defaults driven attribute to specify mode when rendering template.  Remediates error message below:

```json
{"changed": true, "cmd": ["netplan", "generate"], "delta": "0:00:01.119055", "end": "2023-08-27 01:58:23.988600", "msg": "non-zero return code", "rc": 1, "start": "2023-08-27 01:58:22.869545", "stderr": "\n** (generate:2668): WARNING **: 01:58:23.846: Permissions for /etc/netplan/armbian-default.yaml are too open. Netplan configuration should NOT be accessible by others.\n/etc/netplan/armbian-default.yaml:3:12: Error in network definition: unknown renderer ''\n  renderer: \n           ^", "stderr_lines": ["", "** (generate:2668): WARNING **: 01:58:23.846: Permissions for /etc/netplan/armbian-default.yaml are too open. Netplan configuration should NOT be accessible by others.", "/etc/netplan/armbian-default.yaml:3:12: Error in network definition: unknown renderer ''", "  renderer: ", "           ^"], "stdout": "", "stdout_lines": []}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
