### PR TITLE
Add option to backup existing files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,8 @@ netplan_configuration:
 
 netplan_remove_existing: false
 
+netplan_backup_existing: false
+
 netplan_packages:
   - nplan
   - netplan.io

--- a/tasks/existing.yml
+++ b/tasks/existing.yml
@@ -8,6 +8,17 @@
 - debug: var=_netplan_configs
   when: debug is defined and ( debug | bool )
 
+- name: Backup Existing Configurations
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{item['path']}}"
+    dest: "{{item['path']}}.bk"
+  with_items: "{{ _netplan_configs['files'] }}"
+  when:
+    - netplan_backup_existing
+    - item['path'] != netplan_config_file
+    - netplan_configuration != []
+
 - name: Removing Existing Configurations
   file:
     path: "{{ item['path'] }}"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Add an option to backup existing file before removing them.
This creates a copy of an existing `foo.yaml` file to `foo.yaml.bk`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
