### PR TITLE
Add support for dummy-devices

### DIFF
--- a/molecule/dummy-devices/converge.yml
+++ b/molecule/dummy-devices/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  vars:
+    debug: true
+    netplan_configuration:
+      network:
+        version: 2
+        dummy-devices:
+          dm0:
+            addresses:
+              - 10.42.42.2/32
+  tasks:
+    - name: "Include ansible-netplan"
+      include_role:
+        name: "mrlesmithjr.netplan"

--- a/molecule/dummy-devices/molecule.yml
+++ b/molecule/dummy-devices/molecule.yml
@@ -1,0 +1,24 @@
+---
+dependency:
+  name: galaxy
+  options:
+    ignore-certs: true
+    ignore-errors: true
+driver:
+  name: vagrant
+platforms:
+  - name: vagrant-ubuntu
+    box: ubuntu/focal64
+    memory: 4048
+    cpus: 4
+    instance_raw_config_args:
+      - "vm.network 'forwarded_port', guest: 8081, host: 30080"
+provisioner:
+  name: ansible
+  lint: ansible-lint --force-color
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+verifier:
+  name: ansible

--- a/molecule/dummy-devices/prepare.yml
+++ b/molecule/dummy-devices/prepare.yml
@@ -1,0 +1,10 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_os_family == 'Debian'

--- a/molecule/dummy-devices/verify.yml
+++ b/molecule/dummy-devices/verify.yml
@@ -1,0 +1,29 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  vars:
+    netplan_configuration:
+      network:
+        version: "2"
+        dummy-devices:
+          dm0:
+            addresses:
+              - 10.42.42.2/32
+  become: true
+  become_user: root
+  tasks:
+    - name: Read netplan config
+      ansible.builtin.slurp:
+        src: "/etc/netplan/ansible-config.yaml"
+      register: netplan_config_encoded
+
+    - name: Check wireguard config
+      ansible.builtin.assert:
+        that:
+          - netplan_configuration.network.version in netplan_config
+          - netplan_configuration.network.dummy-devices.dm0.addresses[0] in netplan_config
+      vars:
+        - netplan_config: "{{ netplan_config_encoded.content | b64decode }}"

--- a/templates/etc/netplan/config.yaml.j2
+++ b/templates/etc/netplan/config.yaml.j2
@@ -28,3 +28,7 @@ network:
   tunnels:
 {{ netplan_configuration['network']['tunnels']|to_nice_yaml|indent(4, true) }}
 {% endif %}
+{% if netplan_configuration['network']['dummy-devices'] is defined %}
+  dummy-devices:
+{{ netplan_configuration['network']['dummy-devices']|to_nice_yaml|indent(4, true) }}
+{% endif %}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Add support for missing `dummy-devices` key. See https://netplan.readthedocs.io/en/latest/netplan-yaml/#properties-for-device-type-dummy-devices for upstream reference.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
