### PR TITLE
fix: declare and install ansible.posix collection dependency

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Check Ansible version
         run: ansible --version
 
+      - name: Install required collections
+        run: ansible-galaxy collection install ansible.posix
+
       - name: Create ansible.cfg with correct roles_path
         run: printf '[defaults]\nroles_path=../' >ansible.cfg
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,3 +19,6 @@ galaxy_info:
     - networking
 
 dependencies: []
+
+collections:
+  - ansible.posix


### PR DESCRIPTION
## Summary
- Declares `ansible.posix` as a collection dependency in `meta/main.yml` (used by `tasks/configure.yml` for `ansible.posix.sysctl`, was undeclared)
- Installs `ansible.posix` in CI before the syntax-check step
- Includes the earlier yamllint trailing-blank-line fix (16fb635, already on master) that was masking this failure

fixes #59

## Test plan
- [x] CI green on this branch (run 28741669827)